### PR TITLE
PLATY-502: Use MdcLoggingExecutionContext to propagate "file referenc…

### DIFF
--- a/app/NotifyModule.scala
+++ b/app/NotifyModule.scala
@@ -25,7 +25,7 @@ import services._
 class NotifyModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =
     Seq(
-      bind[ServiceConfiguration].to[PlayBasedServiceConfiguration].eagerly(),
+      bind[ServiceConfiguration].to[PlayBasedServiceConfiguration],
       bind[FileNotificationDetailsRetriever].to[S3FileNotificationDetailsRetriever],
       bind[NotificationService].to[HttpNotificationService],
       bind[MessageParser].to[S3EventParser],

--- a/app/connectors/aws/S3EventParser.scala
+++ b/app/connectors/aws/S3EventParser.scala
@@ -17,8 +17,8 @@
 package connectors.aws
 
 import javax.inject.Inject
-
 import model.{FileUploadEvent, Message, S3ObjectLocation}
+import play.api.Logger
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json._
@@ -66,9 +66,23 @@ class S3EventParser @Inject()(implicit ec: ExecutionContext) extends MessagePars
 
   private def interpretS3EventMessage(result: S3EventNotification): Future[FileUploadEvent] =
     result.records match {
-      case S3EventNotificationRecord(_, "aws:s3", _, _, ObjectCreatedEventPattern(), s3Details) :: Nil =>
-        Future.successful(FileUploadEvent(S3ObjectLocation(s3Details.bucketName, s3Details.objectKey)))
+      case S3EventNotificationRecord(_, "aws:s3", _, _, ObjectCreatedEventPattern(), s3Details) :: Nil => {
+        import org.slf4j.MDC
+
+        val event = FileUploadEvent(S3ObjectLocation(s3Details.bucketName, s3Details.objectKey))
+        // Can't rely on MdcLoggingExecutionContext to add file-reference to the MDC, in the code below,
+        // because we don't already have the file-reference value when the thread begins executing.
+        // Therefore add file-reference to the MDC manually. This should be the only part of the code where we need to
+        // manually touch the MDC, since subsequent log statements will have access to the file-reference and can thus
+        // use MdcLoggingExecutionContext / LoggingDetails.
+        try {
+          MDC.put("file-reference", event.location.objectKey)
+          Logger.debug(s"Created FileUploadEvent for objectKey: [${event.location.objectKey}].")
+          Future.successful(event)
+        } finally {
+          MDC.remove("file-reference")
+        }
+      }
       case _ => Future.failed(new Exception(s"Unexpected records in event ${result.records.toString}"))
     }
-
 }

--- a/app/connectors/aws/S3FileManager.scala
+++ b/app/connectors/aws/S3FileManager.scala
@@ -20,29 +20,40 @@ import com.amazonaws.services.s3.AmazonS3
 import javax.inject.Inject
 import model.S3ObjectLocation
 import org.apache.commons.io.IOUtils
+import play.api.Logger
 import services.{FileManager, ObjectMetadata, ObjectWithMetadata}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.Try
 import collection.JavaConverters._
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
+import util.logging.LoggingDetails
 
-class S3FileManager @Inject()(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends FileManager {
+class S3FileManager @Inject()(s3Client: AmazonS3) extends FileManager {
 
-  override def retrieveMetadata(objectLocation: S3ObjectLocation): Future[ObjectMetadata] =
+  override def retrieveMetadata(objectLocation: S3ObjectLocation): Future[ObjectMetadata] = {
+    implicit val ld = LoggingDetails.fromS3ObjectLocation(objectLocation)
+
     Future {
       val metadata = s3Client.getObjectMetadata(objectLocation.bucket, objectLocation.objectKey)
+      Logger.debug(s"Fetched metadata for objectKey: [${objectLocation.objectKey}].")
       ObjectMetadata(userMetadata = metadata.getUserMetadata.asScala.toMap, size = metadata.getContentLength)
     }
+  }
 
-  override def retrieveObject(objectLocation: S3ObjectLocation): Future[ObjectWithMetadata] =
+  override def retrieveObject(objectLocation: S3ObjectLocation): Future[ObjectWithMetadata] = {
+    implicit val ld = LoggingDetails.fromS3ObjectLocation(objectLocation)
+
     for {
       s3Object <- Future(s3Client.getObject(objectLocation.bucket, objectLocation.objectKey))
-      content  <- Future.fromTry(Try(IOUtils.toString(s3Object.getObjectContent)))
-    } yield
-      ObjectWithMetadata(
-        content,
-        ObjectMetadata(
-          userMetadata = s3Object.getObjectMetadata.getUserMetadata.asScala.toMap,
-          size         = s3Object.getObjectMetadata.getContentLength))
+      content <- Future.fromTry(Try(IOUtils.toString(s3Object.getObjectContent)))
+    } yield {
+      Logger.debug(s"Fetched object with metadata for objectKey: [${objectLocation.objectKey}].")
 
+      ObjectWithMetadata(content, ObjectMetadata(
+        userMetadata = s3Object.getObjectMetadata.getUserMetadata.asScala.toMap,
+        size = s3Object.getObjectMetadata.getContentLength
+      ))
+    }
+  }
 }

--- a/app/services/MessageProcessingJob.scala
+++ b/app/services/MessageProcessingJob.scala
@@ -71,12 +71,10 @@ class NotifyOnSuccessfulFileUploadMessageProcessingJob @Inject()(
       parsedMessage <- parser.parse(message)
       notification  <- fileRetriever.retrieveUploadedFileDetails(parsedMessage.location)
       _             <- notificationService.notifySuccessfulCallback(notification)
-
     } yield {
       metrics.defaultRegistry.histogram("fileSize").update(notification.size)
       metrics.defaultRegistry.counter("successfulUploadNotificationSent").inc()
     }
-
 }
 
 class NotifyOnQuarantineFileUploadMessageProcessingJob @Inject()(

--- a/app/services/QueueConsumer.scala
+++ b/app/services/QueueConsumer.scala
@@ -21,7 +21,7 @@ import model.Message
 import scala.concurrent.Future
 
 trait QueueConsumer {
-  def poll(): Future[List[Message]]
+  def poll(): Future[Seq[Message]]
 
   def confirm(message: Message): Future[Unit]
 }

--- a/app/util/logging/LoggingDetails.scala
+++ b/app/util/logging/LoggingDetails.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util.logging
+
+import model.{FileReference, S3ObjectLocation}
+import uk.gov.hmrc.http.HeaderCarrier
+
+/**
+ * Convenience methods to create a [[uk.gov.hmrc.http.logging.LoggingDetails]] instance, required by [[uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext]].
+ */
+object LoggingDetails {
+  def fromS3ObjectLocation(s3ObjectLocation: S3ObjectLocation): HeaderCarrier =
+    fromString(s3ObjectLocation.objectKey)
+
+  def fromFileReference(fileReference: FileReference): HeaderCarrier =
+    fromString(fileReference.reference)
+
+  private def fromString(reference: String): HeaderCarrier =
+    new HeaderCarrier() {
+      override lazy val mdcData: Map[String, String] = super.mdcData + ("file-reference" -> reference)
+    }
+}

--- a/test/connectors/HttpNotificationServiceSpec.scala
+++ b/test/connectors/HttpNotificationServiceSpec.scala
@@ -24,7 +24,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.typesafe.config.Config
-import model.{QuarantinedFile, UploadedFile}
+import model.{FileReference, QuarantinedFile, UploadedFile}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, GivenWhenThen, Matchers}
 import play.api.libs.ws.ahc.AhcWSClient
@@ -32,9 +32,8 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import uk.gov.hmrc.play.http.ws.WSHttp
 import uk.gov.hmrc.play.test.UnitSpec
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.Await
 import scala.util.Try
 
 class HttpNotificationServiceSpec
@@ -76,8 +75,8 @@ class HttpNotificationServiceSpec
       stubCallbackReceiverToReturnValidResponse()
 
       When("the service is called")
-      val notification = UploadedFile(callbackUrl, "upload-file-reference", downloadUrl, 0L)
-      val service      = new HttpNotificationService(new TestHttpClient)(ExecutionContext.Implicits.global)
+      val notification = UploadedFile(callbackUrl, FileReference("upload-file-reference"), downloadUrl, 0L)
+      val service      = new HttpNotificationService(new TestHttpClient)
       val result       = Try(Await.result(service.notifySuccessfulCallback(notification), 30.seconds))
 
       Then("service should return success")
@@ -103,8 +102,8 @@ class HttpNotificationServiceSpec
       stubCallbackReceiverToReturnValidResponse()
 
       When("the service is called")
-      val notification = QuarantinedFile(callbackUrl, "quarantine-file-reference", "This file has a virus")
-      val service      = new HttpNotificationService(new TestHttpClient)(ExecutionContext.Implicits.global)
+      val notification = QuarantinedFile(callbackUrl, FileReference("quarantine-file-reference"), "This file has a virus")
+      val service      = new HttpNotificationService(new TestHttpClient)
       val result       = Try(Await.result(service.notifyFailedCallback(notification), 30.seconds))
 
       Then("service should return success")
@@ -130,8 +129,8 @@ class HttpNotificationServiceSpec
       stubCallbackReceiverToReturnInvalidResponse()
 
       When("the service is called")
-      val notification = UploadedFile(callbackUrl, "file-reference", downloadUrl, 0L)
-      val service      = new HttpNotificationService(new TestHttpClient)(ExecutionContext.Implicits.global)
+      val notification = UploadedFile(callbackUrl, FileReference("file-reference"), downloadUrl, 0L)
+      val service      = new HttpNotificationService(new TestHttpClient)
       val result       = Try(Await.result(service.notifySuccessfulCallback(notification), 30.seconds))
 
       Then("service should return an error")
@@ -146,8 +145,8 @@ class HttpNotificationServiceSpec
       stubCallbackReceiverToReturnInvalidResponse()
 
       When("the service is called")
-      val notification = UploadedFile(callbackUrl, "file-reference", downloadUrl, 0L)
-      val service      = new HttpNotificationService(new TestHttpClient)(ExecutionContext.Implicits.global)
+      val notification = UploadedFile(callbackUrl, FileReference("file-reference"), downloadUrl, 0L)
+      val service      = new HttpNotificationService(new TestHttpClient)
       val result       = Try(Await.result(service.notifySuccessfulCallback(notification), 30.seconds))
 
       Then("service should return an error")
@@ -163,5 +162,4 @@ class TestHttpClient extends HttpClient with WSHttp {
   override val wsClient                           = AhcWSClient()
   override lazy val configuration: Option[Config] = None
   override val hooks                              = Seq.empty
-
 }

--- a/test/connectors/aws/SqsQueueConsumerSpec.scala
+++ b/test/connectors/aws/SqsQueueConsumerSpec.scala
@@ -76,7 +76,7 @@ class SqsQueueConsumerSpec extends UnitSpec with Matchers with Assertions with G
       val consumer = new SqsQueueConsumer(sqsClient, "Test.aws.sqs.queue") {}
 
       When("the consumer poll method is called")
-      val messages: List[Message] = Await.result(consumer.poll(), 2.seconds)
+      val messages: Seq[Message] = Await.result(consumer.poll(), 2.seconds)
 
       Then("the SQS endpoint should be called")
       Mockito.verify(sqsClient).receiveMessage(any(): ReceiveMessageRequest)
@@ -97,7 +97,7 @@ class SqsQueueConsumerSpec extends UnitSpec with Matchers with Assertions with G
       val consumer = new SqsQueueConsumer(sqsClient, "Test.aws.sqs.queue") {}
 
       When("the consumer poll method is called")
-      val messages: List[Message] = Await.result(consumer.poll(), 2.seconds)
+      val messages: Seq[Message] = Await.result(consumer.poll(), 2.seconds)
 
       Then("the SQS endpoint should be called")
       Mockito.verify(sqsClient).receiveMessage(any(): ReceiveMessageRequest)

--- a/test/services/NotifyOnFileProcessingEventFlowSpec.scala
+++ b/test/services/NotifyOnFileProcessingEventFlowSpec.scala
@@ -51,7 +51,7 @@ class NotifyOnFileProcessingEventFlowSpec extends UnitSpec with Matchers with Gi
 
   val fileDetailsRetriever = new FileNotificationDetailsRetriever {
     override def retrieveUploadedFileDetails(objectLocation: S3ObjectLocation): Future[UploadedFile] =
-      Future.successful(UploadedFile(callbackUrl, objectLocation.objectKey, downloadUrl, 10L))
+      Future.successful(UploadedFile(callbackUrl, FileReference(objectLocation.objectKey), downloadUrl, 10L))
 
     override def retrieveQuarantinedFileDetails(objectLocation: S3ObjectLocation): Future[QuarantinedFile] = ???
   }
@@ -162,15 +162,15 @@ class NotifyOnFileProcessingEventFlowSpec extends UnitSpec with Matchers with Gi
 
       val notificationService = mock[NotificationService]
       Mockito
-        .when(notificationService.notifySuccessfulCallback(UploadedFile(callbackUrl, "ID1", downloadUrl, 10L)))
+        .when(notificationService.notifySuccessfulCallback(UploadedFile(callbackUrl, FileReference("ID1"), downloadUrl, 10L)))
         .thenReturn(Future.successful(()))
 
       Mockito
-        .when(notificationService.notifySuccessfulCallback(UploadedFile(callbackUrl, "ID2", downloadUrl, 10L)))
+        .when(notificationService.notifySuccessfulCallback(UploadedFile(callbackUrl, FileReference("ID2"), downloadUrl, 10L)))
         .thenReturn(Future.failed(new Exception("Planned exception")))
 
       Mockito
-        .when(notificationService.notifySuccessfulCallback(UploadedFile(callbackUrl, "ID3", downloadUrl, 10L)))
+        .when(notificationService.notifySuccessfulCallback(UploadedFile(callbackUrl, FileReference("ID3"), downloadUrl, 10L)))
         .thenReturn(Future.successful(()))
 
       val metrics = metricsStub()


### PR DESCRIPTION
…e" value between execution contexts and include in logging statements via MDC.