### PR TITLE
Use public bintray resolvers. These should be used because the projec…

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,10 @@
 credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 
-val hmrcRepoHost = java.lang.System.getProperty("hmrc.repo.host", "https://nexus-preview.tax.service.gov.uk")
+resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-resolvers ++= Seq(
-  "hmrc-snapshots" at hmrcRepoHost + "/content/repositories/hmrc-snapshots",
-  "hmrc-releases" at hmrcRepoHost + "/content/repositories/hmrc-releases",
-  "typesafe-releases" at hmrcRepoHost + "/content/repositories/typesafe-releases",
-  Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
-    Resolver.ivyStylePatterns)
-)
+resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+
+resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 
@@ -30,4 +26,3 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,3 @@
---- 
 leakDetectionExemptions:
   - ruleId: 'ip_addresses'
     filePaths:


### PR DESCRIPTION
…t is public, and to stop the Leak Detection Service alerting on the reference to a .gov.uk hostname.