### PR TITLE
BDOG-585: add default for aws.s3.urlExpirationPeriod

### DIFF
--- a/app/config/ServiceConfiguration.scala
+++ b/app/config/ServiceConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/ServiceConfiguration.scala
+++ b/app/config/ServiceConfiguration.scala
@@ -83,9 +83,9 @@ class PlayBasedServiceConfiguration @Inject()(configuration: Configuration, env:
     serviceName.replaceAll("[/.]", "-")
 
   private def validS3UrlExpirationPeriodWithKey(key: String): Option[(String, FiniteDuration)] =
-    configuration.getMilliseconds(key).map(_.milliseconds).
-      filter(_ <= S3UrlExpirationPeriod.MaxValue).
-      map(key -> _)
+    configuration.getMilliseconds(key).map(_.milliseconds)
+      .filter(_ <= S3UrlExpirationPeriod.MaxValue)
+      .map(key -> _)
 
   private def configKeyForDefault(configDescriptor: String): String =
     s"${runMode.env}.upscan.default.$configDescriptor"

--- a/app/config/UpscanQueuesModule.scala
+++ b/app/config/UpscanQueuesModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/HttpNotificationService.scala
+++ b/app/connectors/HttpNotificationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/aws/AWSClientModule.scala
+++ b/app/connectors/aws/AWSClientModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/aws/S3DownloadUrlGenerator.scala
+++ b/app/connectors/aws/S3DownloadUrlGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/aws/S3EventParser.scala
+++ b/app/connectors/aws/S3EventParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/aws/S3FileManager.scala
+++ b/app/connectors/aws/S3FileManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/aws/SqsQueueConsumer.scala
+++ b/app/connectors/aws/SqsQueueConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/model/JsonWriteHelpers.scala
+++ b/app/model/JsonWriteHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/model/package.scala
+++ b/app/model/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/modules/NotifyModule.scala
+++ b/app/modules/NotifyModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/ContinuousPoller.scala
+++ b/app/services/ContinuousPoller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/DownloadUrlGenerator.scala
+++ b/app/services/DownloadUrlGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/FileManager.scala
+++ b/app/services/FileManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/FileNotificationDetailsRetriever.scala
+++ b/app/services/FileNotificationDetailsRetriever.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/MessageParser.scala
+++ b/app/services/MessageParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/MessageProcessingJob.scala
+++ b/app/services/MessageProcessingJob.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/NotificationService.scala
+++ b/app/services/NotificationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/QueueConsumer.scala
+++ b/app/services/QueueConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/S3FileNotificationDetailsRetriever.scala
+++ b/app/services/S3FileNotificationDetailsRetriever.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/UpscanAuditingService.scala
+++ b/app/services/UpscanAuditingService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/util/logging/LoggingDetails.scala
+++ b/app/util/logging/LoggingDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/util/logging/WithLoggingDetails.scala
+++ b/app/util/logging/WithLoggingDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2019 HM Revenue & Customs
+# Copyright 2020 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/config/PlayBasedServiceConfigurationSpec.scala
+++ b/test/config/PlayBasedServiceConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/config/PlayBasedServiceConfigurationSpec.scala
+++ b/test/config/PlayBasedServiceConfigurationSpec.scala
@@ -16,39 +16,85 @@
 
 package config
 
+import config.PlayBasedServiceConfiguration.S3UrlExpirationPeriod
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar.mock
 import play.api.{Configuration, Environment, Mode}
+import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.duration._
-import uk.gov.hmrc.play.test.UnitSpec
 
 class PlayBasedServiceConfigurationSpec extends UnitSpec {
 
-  val mockConfiguration = mock[Configuration]
-  val mockEnvironment = mock[Environment]
+  import PlayBasedServiceConfigurationSpec._
 
+  private val mockConfiguration = mock[Configuration]
+  private val mockEnvironment = mock[Environment]
   when(mockEnvironment.mode).thenReturn(Mode.Test)
-
-  val playBasedServiceConfiguration = new PlayBasedServiceConfiguration(mockConfiguration, mockEnvironment)
+  private val playBasedServiceConfiguration = new PlayBasedServiceConfiguration(mockConfiguration, mockEnvironment)
 
   "s3UrlExpirationPeriod" should {
 
-    "return relevant config for a valid serviceName" in {
-      when(mockConfiguration.getMilliseconds("Test.upscan.consuming-services.business-rates-attachments.aws.s3.urlExpirationPeriod"))
-        .thenReturn(Some(1.days.toMillis))
-
-      playBasedServiceConfiguration.s3UrlExpirationPeriod("business-rates-attachments") shouldBe 1.days
-    }
-
     "return relevant config for a translated serviceName with invalid chars" in {
-      when(mockConfiguration.getMilliseconds("Test.upscan.consuming-services.Mozilla-4-0.aws.s3.urlExpirationPeriod"))
-        .thenReturn(Some(1.days.toMillis))
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor("Mozilla-4-0"))).thenReturn(Some(1.days.toMillis))
 
       playBasedServiceConfiguration.s3UrlExpirationPeriod("Mozilla/4.0") shouldBe 1.days
     }
 
+    "return bespoke service configuration when defined and valid (at most 7 days)" in {
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor(SomeServiceName))).thenReturn(Some(2.days.toMillis))
 
+      playBasedServiceConfiguration.s3UrlExpirationPeriod(SomeServiceName) shouldBe 2.days
+    }
+
+    "return default configuration when valid (at most 7 days) and bespoke service configuration is not defined" in {
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor(SomeServiceName))).thenReturn(None)
+      when(mockConfiguration.getMilliseconds(DefaultS3UrlExpirationKey)).thenReturn(Some(5.days.toMillis))
+
+      playBasedServiceConfiguration.s3UrlExpirationPeriod(SomeServiceName) shouldBe 5.days
+    }
+
+    "return default configuration when valid (at most 7 days) and bespoke service configuration is invalid (greater than 7 days)" in {
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor(SomeServiceName))).thenReturn(Some(8.days.toMillis))
+      when(mockConfiguration.getMilliseconds(DefaultS3UrlExpirationKey)).thenReturn(Some(5.days.toMillis))
+
+      playBasedServiceConfiguration.s3UrlExpirationPeriod(SomeServiceName) shouldBe 5.days
+    }
+
+    "return fallback configuration when default configuration is invalid (greater than 7 days) and bespoke service configuration is not defined" in {
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor(SomeServiceName))).thenReturn(None)
+      when(mockConfiguration.getMilliseconds(DefaultS3UrlExpirationKey)).thenReturn(Some(8.days.toMillis))
+
+      playBasedServiceConfiguration.s3UrlExpirationPeriod(SomeServiceName) shouldBe S3UrlExpirationPeriod.FallbackValue
+    }
+
+    "return fallback configuration when both bespoke service configuration and default configuration are invalid (greater than 7 days)" in {
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor(SomeServiceName))).thenReturn(Some(8.days.toMillis))
+      when(mockConfiguration.getMilliseconds(DefaultS3UrlExpirationKey)).thenReturn(Some(9.days.toMillis))
+
+      playBasedServiceConfiguration.s3UrlExpirationPeriod(SomeServiceName) shouldBe S3UrlExpirationPeriod.FallbackValue
+    }
+
+    "return fallback configuration when neither bespoke service configuration or default configuration are defined" in {
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor(SomeServiceName))).thenReturn(None)
+      when(mockConfiguration.getMilliseconds(DefaultS3UrlExpirationKey)).thenReturn(None)
+
+      playBasedServiceConfiguration.s3UrlExpirationPeriod(SomeServiceName) shouldBe S3UrlExpirationPeriod.FallbackValue
+    }
+
+    "return fallback configuration when bespoke service configuration is invalid (greater than 7 days) and default configuration is not defined" in {
+      when(mockConfiguration.getMilliseconds(s3UrlExpirationPeriodKeyFor(SomeServiceName))).thenReturn(Some(8.days.toMillis))
+      when(mockConfiguration.getMilliseconds(DefaultS3UrlExpirationKey)).thenReturn(None)
+
+      playBasedServiceConfiguration.s3UrlExpirationPeriod(SomeServiceName) shouldBe S3UrlExpirationPeriod.FallbackValue
+    }
   }
+}
 
+private object PlayBasedServiceConfigurationSpec {
+  val SomeServiceName = "business-rates-attachments"
+  val DefaultS3UrlExpirationKey = "Test.upscan.default.aws.s3.urlExpirationPeriod"
+
+  def s3UrlExpirationPeriodKeyFor(service: String): String =
+    s"Test.upscan.consuming-services.$service.aws.s3.urlExpirationPeriod"
 }

--- a/test/connectors/HttpNotificationServiceSpec.scala
+++ b/test/connectors/HttpNotificationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/aws/ProviderOfAWSCredentialsSpec.scala
+++ b/test/connectors/aws/ProviderOfAWSCredentialsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/aws/S3DownloadUrlGeneratorSpec.scala
+++ b/test/connectors/aws/S3DownloadUrlGeneratorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/aws/S3EventMessageParserSpec.scala
+++ b/test/connectors/aws/S3EventMessageParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/aws/S3FileManagerSpec.scala
+++ b/test/connectors/aws/S3FileManagerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/connectors/aws/SqsQueueConsumerSpec.scala
+++ b/test/connectors/aws/SqsQueueConsumerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/model/FileProcessingDetailsSpec.scala
+++ b/test/model/FileProcessingDetailsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/ContinuousPollerSpec.scala
+++ b/test/services/ContinuousPollerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/NotifyOnFileProcessingEventFlowSpec.scala
+++ b/test/services/NotifyOnFileProcessingEventFlowSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/NotifyOnQuarantineFileUploadMessageProcessingJobSpec.scala
+++ b/test/services/NotifyOnQuarantineFileUploadMessageProcessingJobSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/NotifyOnSuccessfulFileUploadMessageProcessingJobSpec.scala
+++ b/test/services/NotifyOnSuccessfulFileUploadMessageProcessingJobSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/S3FileNotificationDetailsRetrieverSpec.scala
+++ b/test/services/S3FileNotificationDetailsRetrieverSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/UpscanAuditingServiceSpec.scala
+++ b/test/services/UpscanAuditingServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/IncrementingClock.scala
+++ b/test/util/IncrementingClock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/logging/MockLoggerLike.scala
+++ b/test/util/logging/MockLoggerLike.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/logging/WithLoggingDetailsSpec.scala
+++ b/test/util/logging/WithLoggingDetailsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
If a service does not configure a bespoke value for aws.s3.urlExpirationPeriod under the consuming-services key, or the specified value is invalid, use a default value specified in the configuration.

If the default value is missing from the configuration or invalid fallback to 1 day.