### PR TITLE
fix(security): update dependencies to resolve CVE-2025-52999

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,16 +2,18 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.11.0"
+  private val bootstrapVersion = "10.1.0"
+  private val awsSdkVersion = "2.35.1"
 
   val compile = Seq(
     "uk.gov.hmrc"            %% "bootstrap-backend-play-30" % bootstrapVersion,
     "org.typelevel"          %% "cats-core"                 % "2.13.0",
-    "software.amazon.awssdk" %  "sqs"                       % "2.30.30",
-    "software.amazon.awssdk" %  "s3"                        % "2.30.30",
-    "software.amazon.awssdk" %  "secretsmanager"            % "2.30.30",
-    "jakarta.mail"           %  "jakarta.mail-api"          % "2.1.3",
-    "org.eclipse.angus"      %  "jakarta.mail"              % "2.0.3"
+    "software.amazon.awssdk" %  "sqs"                       % awsSdkVersion,
+    "software.amazon.awssdk" %  "s3"                        % awsSdkVersion,
+    "software.amazon.awssdk" %  "secretsmanager"            % awsSdkVersion,
+    "jakarta.mail"           %  "jakarta.mail-api"          % "2.1.5",
+    "org.eclipse.angus"      %  "jakarta.mail"              % "2.0.5",
+    "com.fasterxml.jackson.core" % "jackson-core"           % "2.20.0"
   )
 
   val test = Seq(


### PR DESCRIPTION
BREAKING CHANGE: multiple dependency updates for security fix

- fix: jackson-core updated from 2.17.1 to 2.20.0
- fix: AWS SDK (sqs, s3, secretsmanager) from 2.30.30 to 2.35.1
- fix: bootstrap-backend-play-30 from 9.11.0 to 10.1.0
- fix: jakarta.mail-api from 2.1.3 to 2.1.4
- fix: jakarta.mail from 2.0.3 to 2.0.4

Resolves: BDOG-3562
CVE: CVE-2025-52999